### PR TITLE
Adding a mocha.opts file for constant `--compiler coffee:coffee-script` and other arguments

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--reporter spec
+--compilers coffee:coffee-script


### PR DESCRIPTION
Pretty self explanatory but, adding a mocha.opts file to hold all of the mocha options.
